### PR TITLE
DEV: Remove use of deprecated auth_provider option

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -89,7 +89,6 @@ class OmniAuth::Strategies::Sketchup
 end
 
 auth_provider title: "with SketchUp",
-              message: "Authenticating with SketchUp (make sure your pop up blocker is disabled).",
               frame_width: 725,
               frame_height: 600,
               authenticator: SketchupAuthenticator.new


### PR DESCRIPTION
### What is this change?

This option is deprecated roughly 4 years ago, and was marked for removal in 2.9.0.

https://github.com/discourse/discourse/blob/d0881e6fef05df04fb88c3c87335698d4dc4fb61/lib/auth/auth_provider.rb#L51-L56