### PR TITLE
DEV: Fix a MultiJson deprecation

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -78,7 +78,7 @@ class OmniAuth::Strategies::Sketchup
           },
         )
 
-      @auth_data = MultiJson.decode(response.body.to_s)
+      @auth_data = MultiJson.load(response.body.to_s)
       super
     else
       fail!(:invalid_request)


### PR DESCRIPTION
```
MultiJson.decode is deprecated and will be removed in v2.0. Use MultiJson.load instead.
```